### PR TITLE
See answers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ KEYS.md
 yarn.lock
 
 *.dump.gz
+
+# Ignore setup shell script.
+/start_icq.sh

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem 'capybara'
   gem 'rails-controller-testing'
   gem 'database_cleaner-active_record'
+  gem 'selenium-webdriver'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     database_cleaner (1.8.5)
@@ -233,6 +235,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
+    rubyzip (1.3.0)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -241,6 +244,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (2.53.4)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sexp_processor (4.15.1)
     simplecov (0.19.0)
       docile (~> 1.1)
@@ -273,6 +280,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    websocket (1.2.8)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -305,6 +313,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   sassc-rails
+  selenium-webdriver
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/javascripts/myapp.js
+++ b/app/assets/javascripts/myapp.js
@@ -277,6 +277,11 @@ var ICQ = (function() {
         setTimeout(monitor_question_status, 1000, ids);
     };
 
+    var add_option_textbox = function(){
+        console.log("Am here");
+        jQuery("#display").innerHTML = jQuery("#display").innerHTML + "got here!";
+    };
+
     return {
         init: function() {
             jQuery("#question_type").on('change', function() {
@@ -305,6 +310,31 @@ var ICQ = (function() {
             jQuery("#showanswer").on('click', function() {
                 jQuery(".answer").toggle();
             });
+            
+            
+            jQuery(document).ready(function() {
+
+                jQuery(".add_field_button").click(function(e){ //on add input button click
+                    e.preventDefault();
+                    jQuery('.input_fields_wrap').append('<div><input class="option_input "type="text" name="mytext[]"/><a href="#" class="remove_field">Remove</a></div>'); //add input box
+                });
+    
+                jQuery(".input_fields_wrap").on("click",".remove_field", function(e){ //user click on remove text
+                    e.preventDefault(); 
+                    jQuery(this).parent('div').remove();
+                });
+                
+                jQuery(".save_fields_button").click(function(e){
+                    e.preventDefault();
+                    options = []
+                    jQuery("input[type=text].option_input").each(function(){
+                        options.push(jQuery(this).val());
+                    });
+                    jQuery("#qcontent").val(options.join("\n"));
+                });
+            });
+            
+            
             jQuery("#new_free_response_poll_response").on('ajax:success', student_response_handler);
             jQuery("#new_multi_choice_poll_response").on('ajax:success', student_response_handler);
             jQuery("#new_numeric_response_poll_response").on('ajax:success', student_response_handler);

--- a/app/assets/javascripts/myapp.js
+++ b/app/assets/javascripts/myapp.js
@@ -277,11 +277,6 @@ var ICQ = (function() {
         setTimeout(monitor_question_status, 1000, ids);
     };
 
-    var add_option_textbox = function(){
-        console.log("Am here");
-        jQuery("#display").innerHTML = jQuery("#display").innerHTML + "got here!";
-    };
-
     return {
         init: function() {
             jQuery("#question_type").on('change', function() {
@@ -311,27 +306,24 @@ var ICQ = (function() {
                 jQuery(".answer").toggle();
             });
             
-            
-            jQuery(document).ready(function() {
+            //Create-question form handlers
+            jQuery(".add_field_button").click(function(e){ //on add input button click
+                e.preventDefault();
+                jQuery('.input_fields_wrap').append('<div><input class="option_input" type="text" name="question[option]"/><a href="#" class="remove_field">Remove</a></div>'); //add input box
+            });
 
-                jQuery(".add_field_button").click(function(e){ //on add input button click
-                    e.preventDefault();
-                    jQuery('.input_fields_wrap').append('<div><input class="option_input "type="text" name="mytext[]"/><a href="#" class="remove_field">Remove</a></div>'); //add input box
+            jQuery(".input_fields_wrap").on("click",".remove_field", function(e){ //user click on remove text
+                e.preventDefault(); 
+                jQuery(this).parent('div').remove();
+            });
+            
+            jQuery(".save_fields_button").click(function(e){
+                e.preventDefault();
+                options = []
+                jQuery("input[type=text].option_input").each(function(){
+                    options.push(jQuery(this).val());
                 });
-    
-                jQuery(".input_fields_wrap").on("click",".remove_field", function(e){ //user click on remove text
-                    e.preventDefault(); 
-                    jQuery(this).parent('div').remove();
-                });
-                
-                jQuery(".save_fields_button").click(function(e){
-                    e.preventDefault();
-                    options = []
-                    jQuery("input[type=text].option_input").each(function(){
-                        options.push(jQuery(this).val());
-                    });
-                    jQuery("#qcontent").val(options.join("\n"));
-                });
+                jQuery("#qcontent").val(options.join("\n"));
             });
             
             

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -41,7 +41,7 @@ private
     p = params.require(:question).permit(:qname, :type, :qcontent, :content_type, :answer, :image)
     # reform qcontent into an array
     if p[:qcontent]
-      p[:qcontent] = p[:qcontent].split.collect { |s| s.strip }
+      p[:qcontent] = p[:qcontent].split("\n").collect { |s| s.strip }
     end
     p
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -27,8 +27,8 @@ protected
   end
   
   def answer_for_multichoice
-    if not qcontent.include? answer
-      errors.add(answer, "not in the offered answers")
+    if type == "MultiChoiceQuestion" and not qcontent.include? answer
+      errors.add(:answer, "Not in the offered answers")
     end
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,7 +3,7 @@ class Question < ApplicationRecord
   has_many :polls, :dependent => :destroy
   validates :qname, presence: true
   validates_associated :course
-  validate :options_for_multichoice
+  validate :options_for_multichoice, :answer_for_multichoice
   enum content_type: %i(html markdown plain)
   has_one_attached :image
 
@@ -23,6 +23,12 @@ protected
   def options_for_multichoice
     if type == "MultiChoiceQuestion" and qcontent.length < 2
       errors.add(:qcontent, "missing newline-separated options for multichoice question")
+    end
+  end
+  
+  def answer_for_multichoice
+    if not qcontent.include? answer
+      errors.add(answer, "not in the offered answers")
     end
   end
 

--- a/app/views/questions/new.html.haml
+++ b/app/views/questions/new.html.haml
@@ -16,7 +16,8 @@
       
       =f.label :qadd, "Add options:"
       %button.add_field_button Add an option
-      // this div is needed for adding the jquery inputs
+      
+      //this div is needed for adding the jQuery inputs
       .input_fields_wrap
       %br
       

--- a/app/views/questions/new.html.haml
+++ b/app/views/questions/new.html.haml
@@ -5,19 +5,36 @@
       =f.label :qname, "Question text:"
       =f.text_field :qname
       %br
+      
       =f.label :type, "Question type:"
       =f.select :type, question_types
       %br
-      =f.label :qcontent, "Options:"
-      =f.text_area :qcontent
+      
+      //=f.label :qcontent, "Options:"
+      =f.text_area :qcontent, :style => "display:none", :id => "qcontent"
       %br
+      
+      =f.label :qadd, "Add options:"
+      %button.add_field_button Add an option
+      // this div is needed for adding the jquery inputs
+      .input_fields_wrap
+      %br
+      
+      =f.label :qsave, "Save options:"
+      %button.save_fields_button Save current options
+      %br
+      
       =f.label :answer, 'Answer:'
       =f.text_field :answer
       %br
+      
       =f.label :image, "Image"
       =f.file_field :image, :accept => 'image/png,image/gif,image/jpeg,image/pdf'
       %br
+      
       =f.submit "Create question"
-
   #bottom
     =link_to "Back to question index", course_questions_path(@course)
+    
+    
+    //#display Hello?

--- a/spec/features/destroy_question_spec.rb
+++ b/spec/features/destroy_question_spec.rb
@@ -1,20 +1,25 @@
 require 'rails_helper' 
 RSpec.feature "DestroyQuestions", type: :feature do
   include Devise::Test::IntegrationHelpers
-  it "should successfully destroy" do
-    admin = FactoryBot.create(:admin)
-    sign_in admin
-    c = FactoryBot.create(:course)
-    visit course_questions_path(c)
-    click_link "Create a new question"
-    fill_in "question_qname", :with => "TEST"
-    fill_in "question_qcontent", :with => "a\nb\nc"
-    select "MultiChoiceQuestion", from: "question_type"
-    click_on "Create question"
-    expect(page.current_path).to eq(course_questions_path(c))
-    expect(page.text).to match(/TEST/)
-    click_link "destroy_TEST"
-    expect(page.current_path).to eq(course_questions_path(c))
-    expect(page.text).to match(/TEST destroyed/)
+  describe "Destroy questions", js: true do
+      it "should successfully destroy" do
+        admin = FactoryBot.create(:admin)
+        sign_in admin
+        c = FactoryBot.create(:course)
+        # Flakes due to dependency issues with Selenium webdriver
+        visit course_questions_path(c)
+        click_link "Create a new question"
+        fill_in "question_qname", :with => "TEST"
+        click_button "Add an option"
+        fill_in "question_option", :with => "a"
+        click_button "Save current options"
+        fill_in "question_answer", :with => "a"
+        click_button "Create question"
+        expect(page.current_path).to eq(course_questions_path(c))
+        expect(page.text).to match(/TEST/)
+        click_link "destroy_TEST"
+        expect(page.current_path).to eq(course_questions_path(c))
+        expect(page.text).to match(/TEST destroyed/)
+      end
   end
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Poll, type: :model do
 
     it "should give a hash of responses for multichoice polls" do
       c = FactoryBot.create(:course)
-      q = FactoryBot.create(:multi_choice_question, :course => c, :qcontent => %w{one two three})
+      q = FactoryBot.create(:multi_choice_question, :course => c, :qcontent => %w{one two three}, :answer => "one")
       p = q.new_poll(:round => 1, :isopen => false)
       q.save!
       1.upto(10) do |i|


### PR DESCRIPTION
We now have separate text boxes for question options input, which get displayed as options to students! A few notes: 

- as of now, the options can only be in one line, so snippets of code are sadly still out of the picture
- this is not very thoroughly tested, but it should be working well on most fronts
- there is a "Save options" button that has to be pressed in order for the options to be processed 
- - this can be fixed such that the submit button both saves the options and submits the form, maybe something we can consider for iteration 3
- the functionality is overall not different from what was there before, it just makes the question creation UI more intuitive
- the JavaScript makes use of a hidden text box to get the collected options to the params hash, something to be aware of

Have a great Thanksgiving everyone!

Joakim
